### PR TITLE
fix: prevent duplicate title in exported YAML frontmatter

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -145,8 +145,15 @@ export default class ObsidianToQuartoPlugin extends Plugin {
             mainContent = content.slice(frontmatter.length);
         }
 
-        // Create new frontmatter
-        const title = file.basename;
+        // Use title from existing frontmatter if present, otherwise fall back to filename
+        let existingTitle: string | null = null;
+        if (frontmatter) {
+            const titleMatch = frontmatter.match(/^title:\s*["']?(.+?)["']?\s*$/m);
+            if (titleMatch) {
+                existingTitle = titleMatch[1].trim();
+            }
+        }
+        const title = existingTitle ?? file.basename;
         let newFrontmatter = `---\ntitle: "${title}"\n`;
 
         if (this.settings.dateOption !== 'none') {
@@ -183,6 +190,10 @@ export default class ObsidianToQuartoPlugin extends Plugin {
             };
 
             for (const line of lines) {
+                // Skip title — already written at the top of newFrontmatter
+                if (/^title\s*:/.test(line)) {
+                    continue;
+                }
                 if (/^tags\s*:/.test(line)) {
                     flushList();
                     inTagsBlock = true;


### PR DESCRIPTION
## Problem

If the source note already contains a `title:` field in its YAML frontmatter, the exporter was unconditionally writing a new `title:` (from the filename) and then appending all existing frontmatter lines without filtering out `title:` — resulting in two `title:` entries and invalid YAML output.

Fixes #6

## Fix

Two small changes to `convertToQuarto()`:

1. **Before building new frontmatter**, scan existing frontmatter for a `title:` entry. If found, use that value instead of the filename. Notes without an explicit title are unaffected (filename fallback still applies).
2. **In the merge loop**, skip `title:` lines (same pattern already used for `tags:`) so the key is never written twice.

## Behaviour

| Scenario | Before | After |
|---|---|---|
| Note has no `title:` in frontmatter | `title: "filename"` | `title: "filename"` (unchanged) |
| Note has `title: "Custom Title"` | `title: "filename"` + `title: "Custom Title"` (duplicate, invalid) | `title: "Custom Title"` (correct) |